### PR TITLE
fix: potential fix for code scanning alert no. 7: Incomplete string escaping or encoding

### DIFF
--- a/src/gadgets/DisambigHelper/DisambigHelper.js
+++ b/src/gadgets/DisambigHelper/DisambigHelper.js
@@ -170,7 +170,7 @@ $(function () {
                 return send(msg.loadingFailed);
             }
             for (const sense of senses) {
-                const safe_sense = sense.replace("\"", "&quot;");
+                const safe_sense = sense.replace(/"/g, "&quot;");
                 $(`#${id_title} ul`).append(`<li id="${safe_sense}">${sense}<a href="/${safe_sense}">${link}</a><a>${edit_icon}</a></li>`);
                 document.getElementById(sense).lastChild.addEventListener("click", async () => {
                     send(msg.editing);


### PR DESCRIPTION
Potential fix for [https://github.com/Saoutax/MWGadgets/security/code-scanning/7](https://github.com/Saoutax/MWGadgets/security/code-scanning/7)

To fix the problem, all occurrences of `"` in `sense` should be escaped, not just the first one. In general, this is done by using `replace` with a global regular expression (`/"/g`) or by using a dedicated encoding function/library. Since we’re only allowed to modify the shown snippet and should avoid changing behavior beyond the bug, the simplest safe fix is to change the `replace` call to use a global regex.

Concretely, in `src/gadgets/DisambigHelper/DisambigHelper.js` around line 173, change:

```js
const safe_sense = sense.replace("\"", "&quot;");
```

to:

```js
const safe_sense = sense.replace(/"/g, "&quot;");
```

This keeps the same semantics (escaping `"` to `&quot;`) while ensuring every `"` is escaped. No additional imports or helper methods are needed, and this does not alter how other characters in `sense` are handled.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- 修复在消歧义释义字符串中对双引号转义不完整的问题，现在会替换所有出现的位置，而不是仅替换第一个。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix incomplete escaping of double quotes in disambiguation sense strings by replacing all occurrences instead of only the first.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- 修复在消歧义释义字符串中对双引号转义不完整的问题，现在会替换所有出现的位置，而不是仅替换第一个。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix incomplete escaping of double quotes in disambiguation sense strings by replacing all occurrences instead of only the first.

</details>

</details>