### PR TITLE
fix: potential fix for code scanning alert no. 6: Incomplete string escaping or encoding

### DIFF
--- a/src/gadgets/DisambigHelper/DisambigHelper.js
+++ b/src/gadgets/DisambigHelper/DisambigHelper.js
@@ -77,7 +77,7 @@ $(function () {
     </style>`;
     $("body").append(style);
 
-    const getLinkTitle = element => decodeURI($(element).attr("href").substring(1)).replace("%2F", "/");
+    const getLinkTitle = element => decodeURI($(element).attr("href").substring(1)).replace(/%2F/g, "/");
 
     const getWikitext = title => {
         return new Promise(resolve => {


### PR DESCRIPTION
Potential fix for [https://github.com/Saoutax/MWGadgets/security/code-scanning/6](https://github.com/Saoutax/MWGadgets/security/code-scanning/6)

In general, to fix this kind of problem you should avoid calling `String.prototype.replace` with a plain string when you need to replace all occurrences. Instead, use a regular expression with the `g` (global) flag so that every instance is replaced, or use a more robust decoding/sanitization library.

In this specific case, we want all `%2F` sequences in the (already `decodeURI`-processed) string to be turned into `/`. The minimal change is to replace `.replace("%2F", "/")` with `.replace(/%2F/g, "/")`. This uses a regular expression that matches `%2F` globally, ensuring every occurrence is replaced. No other logic needs to change, and no new imports are necessary. The change is confined to the `getLinkTitle` definition around line 80 in `src/gadgets/DisambigHelper/DisambigHelper.js`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

错误修复：
- 修复了解码后的链接标题中仅部分将 `%2F` 替换为 `/` 的问题，现在会替换所有出现的位置，而不仅仅是第一次出现。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix partial `%2F` to `/` replacement in decoded link titles by replacing all occurrences instead of only the first.

</details>
- 在 DisambigHelper 中计算链接标题时，确保已解码链接的 href 中所有 `%2F` 序列都被替换为 `/`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

错误修复：
- 修复了解码后的链接标题中仅部分将 `%2F` 替换为 `/` 的问题，现在会替换所有出现的位置，而不仅仅是第一次出现。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix partial `%2F` to `/` replacement in decoded link titles by replacing all occurrences instead of only the first.

</details>

</details>