### PR TITLE
fix: potential fix for code scanning alert no. 5: DOM text reinterpreted as HTML

### DIFF
--- a/src/gadgets/ExtImgRestore/ExtImgRestore.js
+++ b/src/gadgets/ExtImgRestore/ExtImgRestore.js
@@ -1,4 +1,22 @@
 $(() => {
+    // Sanitize potentially untrusted URLs before using them in DOM attributes.
+    function sanitizeUrl(url) {
+        if (!url) {
+            return "";
+        }
+        try {
+            const normalized = new URL(url, window.location && window.location.origin ? window.location.origin : undefined);
+            const forbiddenSchemes = ["javascript:", "data:", "vbscript:"];
+            if (forbiddenSchemes.includes(normalized.protocol)) {
+                return "";
+            }
+            return normalized.toString();
+        } catch (e) {
+            // If the URL is invalid, fall back to an empty string to avoid introducing XSS vectors.
+            return "";
+        }
+    }
+
     if (mw.config.get("wgNamespaceNumber") !== -1 && ($(".moe-img-error").length > 0 || $(".moe-img-blocked").length > 0)) {
         const title = mw.config.get("wgPageName").replace(/_/g, " ");
         new mw.Api()
@@ -17,6 +35,7 @@ $(() => {
                     const $this = $(this);
                     const isLink = $this.is("a");
                     const src = isLink ? $this.attr("href") : $this.attr("data-src-input");
+                    const safeSrc = sanitizeUrl(src);
 
                     const imgRegex = new RegExp(`<img[^>]*src=["']${src.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}["'][^>]*>`, "gi");
                     const matches = [...content.matchAll(imgRegex)];
@@ -37,7 +56,7 @@ $(() => {
                         if (isLink) {
                             const link = $("<a>")
                                 .attr({
-                                    href: src,
+                                    href: safeSrc,
                                     target: $this.attr("target") || "_blank",
                                     rel: $this.attr("rel") || "noopener noreferrer",
                                     class: $this.attr("class") || "",
@@ -49,7 +68,7 @@ $(() => {
                             $this.replaceWith(this);
                         }
                     };
-                    img.src = src;
+                    img.src = safeSrc;
                     img.alt = src;
                 });
             });


### PR DESCRIPTION
Potential fix for [https://github.com/Saoutax/MWGadgets/security/code-scanning/5](https://github.com/Saoutax/MWGadgets/security/code-scanning/5)

General fix: Before using untrusted DOM text (`data-src-input`) as an `href` or `src`, validate and normalize it as a URL, and ensure it cannot use dangerous schemes such as `javascript:`. This prevents XSS even if the browser or other code paths do something unexpected with the attribute value.

Best concrete fix here:

- Introduce a small helper function in this file that:
  - Accepts the raw `src` string.
  - Tries to parse it as a URL using the standard `URL` constructor, with `location.origin` as base for relative URLs.
  - Rejects or neutralizes URLs with dangerous schemes (`javascript:`, `data:`, maybe `vbscript:` etc.).
  - Returns either a safe, normalized URL string or an empty string / safe fallback.
- Use this helper when setting:
  - `img.src`
  - The `href` attribute of the `<a>` element
- Optionally also sanitize `img.alt` (e.g., truncate length), though assigning text to `alt` is not an HTML re-interpretation issue; we can leave it as-is or also run through the same helper, depending on strictness.

Implementation details / locations:

- In `src/gadgets/ExtImgRestore/ExtImgRestore.js`, near the top of the file (but still within what you’ve shown), add a `sanitizeUrl` function.
- Around line 19, after computing `src`, compute `const safeSrc = sanitizeUrl(src);`.
- Replace usages of `src` in:
  - `href: src,` (line 40)
  - `img.src = src;` (line 52)
  - Optionally `img.alt = src;` (line 53) if you wish to keep them consistent,
  with `safeSrc`.
- Keep all other logic (regex, style extraction, link wrapping) unchanged to preserve behavior.

This change introduces no new external dependencies; it relies only on built-in `URL` and `window.location`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- 在将图像和链接的源 URL 赋值给 DOM 属性之前，对其进行校验和规范化，以阻止诸如 `javascript:`、`data:` 和 `vbscript:` 等危险协议。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Validate and normalize image and link source URLs before assigning them to DOM attributes to block dangerous protocols such as javascript:, data:, and vbscript:.

</details>
- 在将图像源和链接 URL 赋值给 `href` 和 `src` 属性之前，对其进行校验和规范化，阻止危险的协议方案，从而修复基于 DOM 的 XSS 漏洞。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- 在将图像和链接的源 URL 赋值给 DOM 属性之前，对其进行校验和规范化，以阻止诸如 `javascript:`、`data:` 和 `vbscript:` 等危险协议。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Validate and normalize image and link source URLs before assigning them to DOM attributes to block dangerous protocols such as javascript:, data:, and vbscript:.

</details>

</details>